### PR TITLE
New plugin tutorial and site organization changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,12 @@
 src/
 update.log
 credits.html
+download.html
 index.html
+installation.html
 tutorial/index.html
 tutorial/manual.html
 tutorial/vm-setup.html
+create_plugin/plugin_step_*.html
+create_plugin/create_plugin.html
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/
 update.log
 credits.html
 download.html
+documentation.html
 index.html
 installation.html
 tutorial/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ update.log
 credits.html
 download.html
 documentation.html
+contact.html
 index.html
 installation.html
 tutorial/index.html

--- a/contact.md
+++ b/contact.md
@@ -6,6 +6,10 @@ CSS:    inc/format.css
 LITMUS^RT Contact Information
 =============================
 
-Please direct any questions regarding LITMUS^RT or its usage to [the LITMUS^RT mailing list](https://wiki.litmus-rt.org/litmus/Mailinglist).
+The public mailing list for the LITMUS^RT project is [litmus-dev@lists.litmus-rt.org](mailto:litmus-dev@lists.litmus-rt.org).
+
+Please use this list for all questions and discussion related to LITMUS^RT development and use. If you are a new user, please don't hesitate to ask questions, but please make sure to read the FAQ first.
+
+You can subscribe to the mailing list at the following address: [https://lists.litmus-rt.org/listinfo/litmus-dev](https://lists.litmus-rt.org/listinfo/litmus-dev).
 
 {{inc/footer.markdown}}

--- a/contact.md
+++ b/contact.md
@@ -8,7 +8,7 @@ LITMUS^RT Contact Information
 
 The public mailing list for the LITMUS^RT project is [litmus-dev@lists.litmus-rt.org](mailto:litmus-dev@lists.litmus-rt.org).
 
-Please use this list for all questions and discussion related to LITMUS^RT development and use. If you are a new user, please don't hesitate to ask questions, but please make sure to read the FAQ first.
+Please use this list for all questions and discussion related to LITMUS^RT development and use. If you are a new user, please don't hesitate to ask questions, but please make sure to [check the documentation](documentation.html) first.
 
 You can subscribe to the mailing list at the following address: [https://lists.litmus-rt.org/listinfo/litmus-dev](https://lists.litmus-rt.org/listinfo/litmus-dev).
 

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,11 @@
+Title:  LITMUS-RT: Contact
+CSS:    inc/format.css
+
+{{inc/header.markdown}}
+
+LITMUS^RT Contact Information
+=============================
+
+Please direct any questions regarding LITMUS^RT or its usage to [the LITMUS^RT mailing list](https://wiki.litmus-rt.org/litmus/Mailinglist).
+
+{{inc/footer.markdown}}

--- a/create_plugin/create_plugin.md
+++ b/create_plugin/create_plugin.md
@@ -1,4 +1,4 @@
-Title:  Writing a LITMUS^RT Scheulder Plugin
+Title:  Writing a LITMUS^RT Scheduler Plugin
 CSS:    ../inc/format.css
 
 {{../inc/header2.markdown}}

--- a/create_plugin/create_plugin.md
+++ b/create_plugin/create_plugin.md
@@ -1,0 +1,28 @@
+Title:  Writing a LITMUS^RT Scheulder Plugin
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Writing a LITMUS^RT Scheduler Plugin
+====================================
+
+In LITMUS, new scheduling policies are implemented as *scheduler plugins*, which are run in kernelspace. This set of instructions describes how to write a scheduler plugin in LITMUS^RT by re-creating the Partitioned-EDF (P-EDF) scheduler.
+
+## Prerequisites
+
+In order to create new scheduler plugins, you must be capable of building the LITMUS^RT kernel from source. If you haven't already, follow the [instructions for building and installing LITMUS^RT](../installation.html).
+
+## Steps
+
+The instructions for implementing a new LITMUS^RT scheduler plugin have been separated into 9 steps:
+
+ 1. [Adding an empty source file to the LITMUS^RT kernel](plugin_step_1.html)
+ 2. [Adding stub functions for a LITMUS^RT plugin](plugin_step_2.html)
+ 3. [Creating debug messages using TRACE](plugin_step_3.html)
+ 4. [Defining per-CPU scheduling state for P-EDF](plugin_step_4.html)
+ 5. [Adding P-EDF scheduling logic](plugin_step_5.html)
+ 6. [Task state changes](plugin_step_6.html)
+ 7. [Adding preemption checks](plugin_step_7.html)
+ 8. [Admitting real-time tasks](plugin_step_8.html)
+ 9. [Exporting plugin topology in `/proc`](plugin_step_9.html)
+

--- a/create_plugin/plugin_step_1.md
+++ b/create_plugin/plugin_step_1.md
@@ -1,0 +1,23 @@
+Title:  Writing a Scheduler Plugin: Step 1
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 1: Adding an empty source file to the LITMUS^RT kernel
+===========================================================
+
+The first step in creating a new plugin will be to create a place for the plugin's code in the LITMUS^RT kernel. These following steps assume that the root kernel source directory is named `litmus-rt`.
+
+```bash
+# Navigate to the "litmus" subdirectory of the LITMUS^RT kernel source tree.
+cd litmus-rt/litmus
+
+# Create an empty file to contain the new plugin
+touch sched_demo.c
+```
+
+After adding the new source file, add `sched_demo.o` to the `obj-y` list in the `litmus` directory's `Makefile`. If you want, re-build the LITMUS^RT kernel to make sure you didn't make any mistakes.
+
+<div class="nav">
+[Next: Step 2 - Stub functions](plugin_step_2.html)
+</div>

--- a/create_plugin/plugin_step_1.md
+++ b/create_plugin/plugin_step_1.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 1: Adding an empty source file to the LITMUS^RT kernel
-===========================================================
+-----------------------------------------------------------
 
 The first step in creating a new plugin will be to create a place for the plugin's code in the LITMUS^RT kernel. These following steps assume that the root kernel source directory is named `litmus-rt`.
 

--- a/create_plugin/plugin_step_2.md
+++ b/create_plugin/plugin_step_2.md
@@ -10,7 +10,7 @@ The first step just added an empty file to the LITMUS^RT kernel. In this step, w
 
 {{TOC}}
 
-## Basic scheduler plugin code
+### Basic scheduler plugin code
 
 Modify `sched_demo.c` to contain the following code, which contains a minimal skeleton of a LITMUS^RT scheduler plugin. For now, the plugin does not do anything, apart from registering itself as an available scheduler:
 
@@ -51,7 +51,7 @@ static int __init init_demo(void)
 module_init(init_demo);
 ```
 
-## Explanation of the plugin code
+### Explanation of the plugin code
 
 This stub scheduler implementation is best explained from the bottom to the top line of `sched_demo.c`:
 
@@ -65,7 +65,7 @@ This stub scheduler implementation is best explained from the bottom to the top 
 
  - Finally, the first function in `sched_demo.c` is the `demo_schedule` function, which is our callback for LITMUS^RT's `schedule` event. This function should provide a pointer to the `task_struct` for the task that should begin executing. If the plugin doesn't wish to schedule a real-time task, it can return `NULL` to allow the default Linux scheduler to schedule non-real-time processes. However, it must always call LITMUS^RT's `sched_state_task_picked` function to inform the kernel that a scheduling decision has been made.
 
-## Testing the plugin
+### Testing the plugin
 
 After you have finished adding the code to `sched_demo.c`, re-compile and re-install the kernel. When you reboot, run the following commands as root:
 
@@ -83,7 +83,7 @@ cd liblitmus
 ./rt-spin 10 100 10
 ```
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step2.c).
 

--- a/create_plugin/plugin_step_2.md
+++ b/create_plugin/plugin_step_2.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 2: Adding stub functions for a LITMUS^RT plugin
-====================================================
+----------------------------------------------------
 
 The first step just added an empty file to the LITMUS^RT kernel. In this step, we'll actually include some placeholder code for the new module.
 
@@ -82,6 +82,10 @@ cd liblitmus
 # Creating a real-time task should fail due to an invalid argument error
 ./rt-spin 10 100 10
 ```
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step2.c).
 
 <div class="nav">
 [Previous: Step 1 - Adding files](plugin_step_1.html) -

--- a/create_plugin/plugin_step_2.md
+++ b/create_plugin/plugin_step_2.md
@@ -1,0 +1,89 @@
+Title:  Writing a Scheduler Plugin: Step 2
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 2: Adding stub functions for a LITMUS^RT plugin
+====================================================
+
+The first step just added an empty file to the LITMUS^RT kernel. In this step, we'll actually include some placeholder code for the new module.
+
+{{TOC}}
+
+## Basic scheduler plugin code
+
+Modify `sched_demo.c` to contain the following code, which contains a minimal skeleton of a LITMUS^RT scheduler plugin. For now, the plugin does not do anything, apart from registering itself as an available scheduler:
+
+```C
+#include <linux/module.h>
+#include <litmus/preempt.h>
+#include <litmus/sched_plugin.h>
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        /* We don't schedule anything for now. NULL means "schedule background work". */
+        return NULL;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+```
+
+## Explanation of the plugin code
+
+This stub scheduler implementation is best explained from the bottom to the top line of `sched_demo.c`:
+
+ - All scheduler plugins in LITMUS^RT are actually Linux kernel modules, which require an initialization function. The `module_init(...)` macro is used to tell the compiler and linker which function to call during initialization. This plugin's initialization function is `init_demo`, so the last line in the plugin's definition is `module_init(init_demo);`.
+
+ - Next from the bottom is the definition for the `init_demo` function, which, as mentioned, must contain any code to initialize the plugin. In our case, all it does is call the LITMUS^RT function, `register_sched_plugin(...)`, to add our scheduling plugin to the list of available schedulers. The `register_sched_plugin` function requires a pointer to a `sched_plugin` struct. Both our initialization function and `register_sched_plugin` will return 0 on success.
+
+ - Above the definition for the `init_demo` function comes a statically-defined `sched_plugin` struct, which provides the LITMUS^RT kernel with a list of callback functions along with the scheduler name. In this case, we're setting the scheduler's name to "DEMO", and providing callback functions to be executed during the `schedule` and `admit_task` events. The full list of function callbacks that can be provided in the `sched_plugin` struct can be seen in the definition of `sched_plugin` in `include/litmus/sched_plugin.h`, in the kernel source tree. Any functions we don't provide will simply fall back to a default no-op.
+
+ - Continuing up from the bottom, next comes the `demo_admit_task` function, which is our callback for LITMUS^RT's `admit_task` event. This function will be called whenever a real-time task attempts to be admitted to the system under this scheduler. For now, we simply reject all tasks by returning an invalid argument error.
+
+ - Finally, the first function in `sched_demo.c` is the `demo_schedule` function, which is our callback for LITMUS^RT's `schedule` event. This function should provide a pointer to the `task_struct` for the task that should begin executing. If the plugin doesn't wish to schedule a real-time task, it can return `NULL` to allow the default Linux scheduler to schedule non-real-time processes. However, it must always call LITMUS^RT's `sched_state_task_picked` function to inform the kernel that a scheduling decision has been made.
+
+## Testing the plugin
+
+After you have finished adding the code to `sched_demo.c`, re-compile and re-install the kernel. When you reboot, run the following commands as root:
+
+```bash
+# Navigate to the directory where you built liblitmus
+cd liblitmus
+
+# Change the current system scheduler to our DEMO plugin
+./setsched DEMO
+
+# This should now print 'DEMO'
+./showsched
+
+# Creating a real-time task should fail due to an invalid argument error
+./rt-spin 10 100 10
+```
+
+<div class="nav">
+[Previous: Step 1 - Adding files](plugin_step_1.html) -
+[Next: Step 3 - `TRACE`](plugin_step_3.html)
+</div>

--- a/create_plugin/plugin_step_3.md
+++ b/create_plugin/plugin_step_3.md
@@ -10,11 +10,11 @@ We know that the code from step 2 is working due to the `EINVAL` error, but but 
 
 {{TOC}}
 
-## Why not use printk in a LITMUS^RT plugin?
+### Why not use printk in a LITMUS^RT plugin?
 
 In most modules for the standard Linux kernel, `printk` is generally the go-to choice for writing debug messages to the kernel log. `printk`, however, requires some kernel locks and therefore can cause deadlock if we use it within a LITMUS^RT plugin when making scheduling decisions. LITMUS^RT provides the `TRACE` macro instead, which functions identically to `printk` from the programmer's perspective but doesn't require locking.
 
-## Modifying our basic code to include a TRACE statement
+### Modifying our basic code to include a TRACE statement
 
 First, add the new header file, needed for the `TRACE` macro, to the list of includes at the start of `sched_demo.c`:
 
@@ -35,7 +35,7 @@ static long demo_admit_task(struct task_struct *tsk)
 
 In this example, we used `TRACE_TASK`, which takes a `task_struct` pointer in addition to the message to print. It will include information about the task in the log, along with the message.
 
-## Viewing LITMUS^RT trace output
+### Viewing LITMUS^RT trace output
 
 For the `TRACE` macro to work, make sure that you have enabled `TRACE() debugging` when configuring your kernel build (it's under `LITMUS^RT`->`Tracing` in the configuration menu).
 
@@ -82,7 +82,7 @@ SCHED_STATE [P0] 0x1 (TASK_SCHEDULED) -> 0x4 (WILL_SCHEDULE)
 
 Messages like this are the result of the configuration option `CONFIG_PREEMPT_STATE_TRACE`, which can be disabled in the kernel configuration. To do so, disable the option at `LITMUS^RT`->`Tracing`->`Trace preemption state machine transitions`.
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step3.c).
 

--- a/create_plugin/plugin_step_3.md
+++ b/create_plugin/plugin_step_3.md
@@ -1,0 +1,74 @@
+Title:  Writing a Scheduler Plugin: Step 3
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 3: Creating debug messages using TRACE
+===========================================
+
+We know that the code from step 2 is working due to the `EINVAL` error, but but debugging a new plugin will likely require recording more detailed logging. Step 3 includes how this can be accomplished in LITMUS^RT plugins.
+
+{{TOC}}
+
+## Why not use printk in a LITMUS^RT plugin?
+
+In most modules for the standard Linux kernel, `printk` is generally the go-to choice for writing debug messages to the kernel log. `printk`, however, requires some kernel locks and therefore can cause deadlock if we use it within a LITMUS^RT plugin when making scheduling decisions. LITMUS^RT provides the `TRACE` macro instead, which functions identically to `printk` from the programmer's perspective but doesn't require locking.
+
+## Modifying our basic code to include a TRACE` statement
+
+Modify the `demo_admit_task` from step 2 to contain a `TRACE` statement:
+
+```C
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+```
+
+In this example, we used `TRACE_TASK`, which takes a `task_struct` pointer in addition to the message to print. It will include information about the task in the log, along with the message.
+
+## Viewing LITMUS^RT trace output
+
+For the `TRACE` macro to work, make sure that you have enabled `TRACE() debugging` when configuring your kernel build (it's under `LITMUS^RT`->`Tracing` in the configuration menu).
+
+After rebuilding the kernel and rebooting, try submitting another real-time task to the DEMO plugin, and viewing the LITMUS^RT log. As root, run these commands:
+
+```bash
+# Start using the DEMO scheduler plugin.
+setsched DEMO
+
+# In the background, start copying the LITMUS^RT log output to a separate file.
+tail -f /dev/litmus/log > debug.txt &
+
+# Try starting a real-time task again.
+liblitmus/rtspin 10 100 10
+
+# View the log
+cat debug.txt
+```
+
+The log should contain lines similar to the following:
+
+```
+17 P0 [alloc_ctrl_page@litmus/ctrldev.c:28]: (rtspin/2076:0) alloc_ctrl_page ctrl_page = ffff9709a4933000
+18 P0 [map_ctrl_page@litmus/ctrldev.c:42]: (rtspin/2076:0) litmus/ctrl: mapping ffff9709a4933000 (pfn:64933) to 0x7f65190b2000 (prot:8000000000000027)
+19 P0 [litmus_ctrl_mmap@litmus/ctrldev.c:117]: (rtspin/2076:0) litmus_ctrl_mmap flags=0x10160073 prot=0x8000000000000027
+20 P0 [vprintk_emit@kernel/printk/printk.c:1854]: Setting up rt task parameters for process 2076.
+21 P0 [map_ctrl_page@litmus/ctrldev.c:42]: (rtspin/2076:0) litmus/ctrl: mapping ffff9709a4933000 (pfn:64933) to 0x7f65190b1000 (prot:8000000000000027)
+22 P0 [litmus_ctrl_mmap@litmus/ctrldev.c:117]: (rtspin/2076:0) litmus_ctrl_mmap flags=0x10162073 prot=0x8000000000000027
+23 P0 [demo_admit_task@litmus/sched_demo.c:19]: (rtspin/2076:0) The task was rejected by the DEMO plugin.
+24 P0 [litmus_ctrl_vm_close@litmus/ctrldev.c:56]: (rtspin/2076:0) litmus_ctrl_vm_close flags=0x18160073 prot=0x25
+25 P0 [litmus_ctrl_vm_close@litmus/ctrldev.c:61]: (rtspin/2076:0) litmus/ctrl: 00007f65190b1000:00007f65190b2000 vma:ffff9709a49f1c00 vma->vm_private_data:          (null) closed.
+26 P0 [litmus_ctrl_vm_close@litmus/ctrldev.c:56]: (rtspin/2076:0) litmus_ctrl_vm_close flags=0x18160073 prot=0x25
+27 P0 [litmus_ctrl_vm_close@litmus/ctrldev.c:61]: (rtspin/2076:0) litmus/ctrl: 00007f65190b2000:00007f65190b3000 vma:ffff9709a49f1540 vma->vm_private_data:          (null) closed.
+28 P1 [exit_litmus@litmus/litmus.c:599]: (rtspin/2076:0) freeing ctrl_page ffff9709a4933000
+```
+
+Notice the line `[demo_admit_task@litmus/sched_demo.c:19]: (rtspin/2076:0) The task was rejected by the DEMO plugin.` corresponding to our `TRACE_TASK` invocation. If you are seeing a lot of "noise" in the log similar to `SCHED_STATE [P0] 0x1 (TASK_SCHEDULED) -> 0x4 (WILL_SCHEDULE)`, this is the result of the configuration option `CONFIG_PREEMPT_STATE_TRACE`, which can be disabled in the kernel configuration (disable the option at `LITMUS^RT`->`Tracing`->`Trace preemption state machine transitions`).
+
+<div class="nav">
+[Previous: Step 2 - Stub functions](plugin_step_2.html) -
+[Next: Step 4 - Per-CPU state](plugin_step_4.html)
+</div>

--- a/create_plugin/plugin_step_3.md
+++ b/create_plugin/plugin_step_3.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 3: Creating debug messages using TRACE
-===========================================
+-------------------------------------------
 
 We know that the code from step 2 is working due to the `EINVAL` error, but but debugging a new plugin will likely require recording more detailed logging. Step 3 includes how this can be accomplished in LITMUS^RT plugins.
 
@@ -33,7 +33,7 @@ In this example, we used `TRACE_TASK`, which takes a `task_struct` pointer in ad
 
 For the `TRACE` macro to work, make sure that you have enabled `TRACE() debugging` when configuring your kernel build (it's under `LITMUS^RT`->`Tracing` in the configuration menu).
 
-After rebuilding the kernel and rebooting, try submitting another real-time task to the DEMO plugin, and viewing the LITMUS^RT log. As root, run these commands:
+After rebuilding the kernel and rebooting, try submitting another real-time task to the DEMO plugin, and viewing the LITMUS^RT log. _As root_, run these commands:
 
 ```bash
 # Start using the DEMO scheduler plugin.
@@ -66,7 +66,19 @@ The log should contain lines similar to the following:
 28 P1 [exit_litmus@litmus/litmus.c:599]: (rtspin/2076:0) freeing ctrl_page ffff9709a4933000
 ```
 
-Notice the line `[demo_admit_task@litmus/sched_demo.c:19]: (rtspin/2076:0) The task was rejected by the DEMO plugin.` corresponding to our `TRACE_TASK` invocation. If you are seeing a lot of "noise" in the log similar to `SCHED_STATE [P0] 0x1 (TASK_SCHEDULED) -> 0x4 (WILL_SCHEDULE)`, this is the result of the configuration option `CONFIG_PREEMPT_STATE_TRACE`, which can be disabled in the kernel configuration (disable the option at `LITMUS^RT`->`Tracing`->`Trace preemption state machine transitions`).
+Notice the line containing `The task was rejected by the DEMO plugin.` corresponding to our `TRACE_TASK` invocation.
+
+Depending on your kernel build configuration, you may also see a lot of "noise" in the log similar to:
+
+```
+SCHED_STATE [P0] 0x1 (TASK_SCHEDULED) -> 0x4 (WILL_SCHEDULE)
+```
+
+Messages like this are the result of the configuration option `CONFIG_PREEMPT_STATE_TRACE`, which can be disabled in the kernel configuration. To do so, disable the option at `LITMUS^RT`->`Tracing`->`Trace preemption state machine transitions`.
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step3.c).
 
 <div class="nav">
 [Previous: Step 2 - Stub functions](plugin_step_2.html) -

--- a/create_plugin/plugin_step_3.md
+++ b/create_plugin/plugin_step_3.md
@@ -16,7 +16,13 @@ In most modules for the standard Linux kernel, `printk` is generally the go-to c
 
 ## Modifying our basic code to include a TRACE statement
 
-Modify the `demo_admit_task` from step 2 to contain a `TRACE` statement:
+First, add the new header file, needed for the `TRACE` macro, to the list of includes at the start of `sched_demo.c`:
+
+```C
+#include <litmus/debug_trace.h>
+```
+
+Second, modify the `demo_admit_task` from step 2 to contain a `TRACE` statement:
 
 ```C
 static long demo_admit_task(struct task_struct *tsk)

--- a/create_plugin/plugin_step_3.md
+++ b/create_plugin/plugin_step_3.md
@@ -14,7 +14,7 @@ We know that the code from step 2 is working due to the `EINVAL` error, but but 
 
 In most modules for the standard Linux kernel, `printk` is generally the go-to choice for writing debug messages to the kernel log. `printk`, however, requires some kernel locks and therefore can cause deadlock if we use it within a LITMUS^RT plugin when making scheduling decisions. LITMUS^RT provides the `TRACE` macro instead, which functions identically to `printk` from the programmer's perspective but doesn't require locking.
 
-## Modifying our basic code to include a TRACE` statement
+## Modifying our basic code to include a TRACE statement
 
 Modify the `demo_admit_task` from step 2 to contain a `TRACE` statement:
 

--- a/create_plugin/plugin_step_4.md
+++ b/create_plugin/plugin_step_4.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 4: Defining per-CPU scheduling state for P-EDF
-===================================================
+---------------------------------------------------
 
 Steps 1 through 3 set up skeleton code for a scheduler plugin, and demonstrated how to log debug messages. In step 4, we'll finally start adding code to support a Partitioned-EDF scheduler, starting with per-CPU state.
 
@@ -106,6 +106,10 @@ This should generate output that includes the following lines (depending on the 
 3 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU2...
 4 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU3...
 ```
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step4.c).
 
 <div class="nav">
 [Previous: Step 3 - `TRACE`](plugin_step_3.html) -

--- a/create_plugin/plugin_step_4.md
+++ b/create_plugin/plugin_step_4.md
@@ -10,7 +10,7 @@ Steps 1 through 3 set up skeleton code for a scheduler plugin, and demonstrated 
 
 {{TOC}}
 
-## Including some headers
+### Including some headers
 
 To begin, add the following lines to the beginning of `litmus/sched_demo.c`:
 
@@ -30,7 +30,7 @@ These includes bring in several definitions we'll need:
  - `litmus/rt_domain.h`: Contains definitions relating to "real-time domains", and includes ready-made definitions for release and ready queues.
  - `litmus/edf_common.h`: Contains common definitions related to EDF priority and EDF-related helper functions.
 
-## Per-processor state
+### Per-processor state
 
 To implement the P-EDF scheduler, we need a ready queue and a release queue on each processor. We will use the `rt_domain_t` abstraction, from `litmus/rt_domain.h` to handle this. We also need to know which task is currently scheduled. For convenience, we'll keep track of each CPU's ID in its local state (this will make preemptions easier in a later step). This leads to the following definition of struct `demo_cpu_state`, which will encompass all CPU-local state of the DEMO scheduler. Add the following definitions near the top (after the `#include`s) of `sched_demo.c`:
 
@@ -50,7 +50,7 @@ static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
 
 Note that we use Linux's per-processor allocation macro, `DEFINE_PER_CPU()`, to statically allocate the state required for the plugin. To make the later code more readable, we also define two accessor macros to wrap Linux's per-cpu data structure API: `cpu_state_for()` and `local_cpu_state()`.
 
-## Initializing the new per-CPU state
+### Initializing the new per-CPU state
 
 To make sure that the per-processor state is properly initialized, we are next going to add the plugin activation callback. The `activate_plugin()` callback of a plugin is invoked when the plugin is selected by the user (with `setsched` in `liblitmus`) and is a good place to implement plugin initialization tasks.
 
@@ -88,7 +88,7 @@ static struct sched_plugin demo_plugin = {
 };
 ```
 
-## Testing the changes
+### Testing the changes
 
 Finally, rebuild the LITMUS^RT kernel and reboot. Like in step 3, we'll test our changes by checking the LITMUS^RT kernel's log:
 
@@ -107,7 +107,7 @@ This should generate output that includes the following lines (depending on the 
 4 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU3...
 ```
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step4.c).
 

--- a/create_plugin/plugin_step_4.md
+++ b/create_plugin/plugin_step_4.md
@@ -1,0 +1,113 @@
+Title:  Writing a Scheduler Plugin: Step 4
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 4: Defining per-CPU scheduling state for P-EDF
+===================================================
+
+Steps 1 through 3 set up skeleton code for a scheduler plugin, and demonstrated how to log debug messages. In step 4, we'll finally start adding code to support a Partitioned-EDF scheduler, starting with per-CPU state.
+
+{{TOC}}
+
+## Including some headers
+
+To begin, add the following lines to the beginning of `litmus/sched_demo.c`:
+
+```C
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/litmus.h>
+#include <litmus/rt_domain.h>
+#include <litmus/edf_common.h>
+```
+
+These includes bring in several definitions we'll need:
+
+ - `linux/percpu.h`: Needed for making CPU-local allocations.
+ - `linux/sched.h`: Needed for the definition of `struct task_struct`.
+ - `litmus/litmus.h`: Contains many necessary definitions for working with LITMUS^RT.
+ - `litmus/rt_domain.h`: Contains definitions relating to "real-time domains", and includes ready-made definitions for release and ready queues.
+ - `litmus/edf_common.h`: Contains common definitions related to EDF priority and EDF-related helper functions.
+
+## Per-processor state
+
+To implement the P-EDF scheduler, we need a ready queue and a release queue on each processor. We will use the `rt_domain_t` abstraction, from `litmus/rt_domain.h` to handle this. We also need to know which task is currently scheduled. For convenience, we'll keep track of each CPU's ID in its local state (this will make preemptions easier in a later step). This leads to the following definition of struct `demo_cpu_state`, which will encompass all CPU-local state of the DEMO scheduler. Add the following definitions near the top (after the `#include`s) of `sched_demo.c`:
+
+```C
+struct demo_cpu_state {
+        rt_domain_t     local_queues;
+        int             cpu;
+
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+```
+
+Note that we use Linux's per-processor allocation macro, `DEFINE_PER_CPU()`, to statically allocate the state required for the plugin. To make the later code more readable, we also define two accessor macros to wrap Linux's per-cpu data structure API: `cpu_state_for()` and `local_cpu_state()`.
+
+## Initializing the new per-CPU state
+
+To make sure that the per-processor state is properly initialized, we are next going to add the plugin activation callback. The `activate_plugin()` callback of a plugin is invoked when the plugin is selected by the user (with `setsched` in `liblitmus`) and is a good place to implement plugin initialization tasks.
+
+In the DEMO plugin, we are simply going to initialize the ready queue and the release queue using `edf_domain_init()` and initialize the two fields `cpu` and `scheduled`. Add the following function to `sched_demo.c`, before the `struct sched_plugin` declaration:
+
+```C
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        // Use our macros to access the per-CPU state for all CPUs
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+
+                state = cpu_state_for(cpu);
+
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues, NULL, NULL);
+        }
+
+        return 0;
+}
+```
+
+Afterwards, adjust the `struct sched_plugin` declaration to include our `demo_activate_plugin` callback:
+
+```C
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+        .activate_plugin        = demo_activate_plugin,
+};
+```
+
+## Testing the changes
+
+Finally, rebuild the LITMUS^RT kernel and reboot. Like in step 3, we'll test our changes by checking the LITMUS^RT kernel's log:
+
+```bash
+sudo cat /dev/litmus/log > debug.txt &
+sudo liblitmus/setsched DEMO
+cat debug.txt
+```
+
+This should generate output that includes the following lines (depending on the number of CPUs in your system):
+
+```
+1 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU0...
+2 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU1...
+3 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU2...
+4 P2 [demo_activate_plugin@litmus/sched_demo.c:48]: Initializing CPU3...
+```
+
+<div class="nav">
+[Previous: Step 3 - `TRACE`](plugin_step_3.html) -
+[Next: Step 5 - Scheduling logic](plugin_step_5.html)
+</div>

--- a/create_plugin/plugin_step_5.md
+++ b/create_plugin/plugin_step_5.md
@@ -10,7 +10,7 @@ Step 4 covered adding necessary state variables to our plugin, so we're now read
 
 {{TOC}}
 
-## More headers related to job parameters and budgets
+### More headers related to job parameters and budgets
 
 Add the following two includes to the list at the start of `sched_demo.c`:
 
@@ -21,7 +21,7 @@ Add the following two includes to the list at the start of `sched_demo.c`:
 
 We will need these headers when managing job- and budget- related information in the scheduler.
 
-## Adding helper functions
+### Adding helper functions
 
 Before diving into the scheduling function, we are going to define two helper functions that will aid in preventing the `schedule()` implementation from becoming too convoluted.
 
@@ -58,7 +58,7 @@ static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_sta
 
 Note that `demo_requeue()` uses `__add_ready()`, but not `__add_release()`. This is because `demo_requeue()` will be called only from contexts where the calling thread already holds the lock for the ready queue.
 
-## Adding scheduling logic
+### Adding scheduling logic
 
 Finally, we can define the P-EDF scheduling logic. Conceptually, it follows these three steps:
 
@@ -158,11 +158,11 @@ The next few lines determine whether a preemption / scheduling decision is requi
 
 The final lines carry out the actual scheduling decision. If `prev` needs to be preempted (in the `if (resched)` block), then the previous task is requeued (if required) using `demo_requeue` and a new task is taken from the ready queue. Otherwise, `next` is simply the locally scheduled task, `local_state->scheduled`, which may be `NULL`. The "local state invariant" is maintained by the `local_state->scheduled = next` assignment.
 
-## Testing
+### Testing
 
 With these changes in place, the kernel should compile and boot without problems. However, scheduling is still not possible because all tasks are still being rejected. Before tasks can be accepted, however, we need to add support for task state changes (i.e., self-suspensions).
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step5.c).
 

--- a/create_plugin/plugin_step_5.md
+++ b/create_plugin/plugin_step_5.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 5: Adding P-EDF scheduling logic
-=====================================
+-------------------------------------
 
 Step 4 covered adding necessary state variables to our plugin, so we're now ready to define how the DEMO plugin selects the task that should be scheduled next. Since we're implementing a P-EDF scheduler, we will use the `edf_preemption_needed()` function from `litmus/edf_common.h` to determine when the previous task should be preempted.
 
@@ -161,6 +161,10 @@ The final lines carry out the actual scheduling decision. If `prev` needs to be 
 ## Testing
 
 With these changes in place, the kernel should compile and boot without problems. However, scheduling is still not possible because all tasks are still being rejected. Before tasks can be accepted, however, we need to add support for task state changes (i.e., self-suspensions).
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step5.c).
 
 <div class="nav">
 [Previous: Step 4 - Per-CPU state](plugin_step_4.html) -

--- a/create_plugin/plugin_step_5.md
+++ b/create_plugin/plugin_step_5.md
@@ -1,0 +1,168 @@
+Title:  Writing a Scheduler Plugin: Step 5
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 5: Adding P-EDF scheduling logic
+=====================================
+
+Step 4 covered adding necessary state variables to our plugin, so we're now ready to define how the DEMO plugin selects the task that should be scheduled next. Since we're implementing a P-EDF scheduler, we will use the `edf_preemption_needed()` function from `litmus/edf_common.h` to determine when the previous task should be preempted.
+
+{{TOC}}
+
+## More headers related to job parameters and budgets
+
+Add the following two includes to the list at the start of `sched_demo.c`:
+
+```C
+#include <litmus/jobs.h>
+#include <litmus/budget.h>
+```
+
+We will need these headers when managing job- and budget- related information in the scheduler.
+
+## Adding helper functions
+
+Before diving into the scheduling function, we are going to define two helper functions that will aid in preventing the `schedule()` implementation from becoming too convoluted.
+
+The first helper, `demo_job_completion()`, is called to process a job when it the job completes. In this simple example, it simply delegates all of the work to the common helper, `prepare_for_next_period()`, declared in `litmus/jobs.h`. In more complicated scheduling policies, additional housekeeping code to be run on job completions may be put here.
+
+```C
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+```
+
+Next, we add the `demo_requeue()` helper function. It is used to place a task on the appropriate queue. If the task has a pending job, it is placed in the (core-local) ready queue. Otherwise, if the next job's earliest release time is in the future, the task will be placed in the (also core-local) release queue.
+
+```C
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+```
+
+Note that `demo_requeue()` uses `__add_ready()`, but not `__add_release()`. This is because `demo_requeue()` will be called only from contexts where the calling thread already holds the lock for the ready queue.
+
+## Adding scheduling logic
+
+Finally, we can define the P-EDF scheduling logic. Conceptually, it follows these three steps:
+
+ 1. Checks what state the previously scheduled real-time task is in (if any)
+ 2. Checks whether a higher-priority job is waiting in the ready queue (i.e., if a preemption is required)
+ 3. Returns the next task to be scheduled (which may be NULL if there is no real-time workload pending)
+
+The scheduler is serialized (with respect to each core) using the ready queue lock `local_state->local_queues.ready_lock`. Reusing the ready queue lock to serialize scheduling decisions is a common idiom in LITMUS^RT. Alternatively, we could also define an additional spinlock inside `struct demo_cpu_state`.
+
+Modify the `demo_schedule` function to contain the following content:
+
+```C
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+```
+
+The scheduler is serialized by obtaining the obtaining the ready queue lock: `raw_spin_lock(&local_state->local_queues.ready_lock)`. Note that interrupts are already disabled when a scheduler plugin's `schedule` callback is invoked, so we do not have to worry about local interrupts within `demo_schedule()`.
+
+The `BUG_ON` lines assert that the following invariant holds: when a real-time task is scheduled on the local core, then it is pointed to by `local_state->scheduled`, and if no real-time task is scheduled, then `local_state->scheduled` is `NULL`. Note that `prev` may refer to a non-real-time task.
+
+The next lines establish the state of `prev`:
+
+ - `exists` is true if the previous task is a real-time task.
+ - `self_suspends` is true if `prev` cannot be scheduled any longer.
+ - `out_of_time` is true if the current job overran its budget.
+ - `job_completed` is true if the current job signaled completion via syscall.
+
+The call to `edf_preemption_needed` checks whether higher-priority work is pending (i.e., jobs with earlier deadlines) on the local ready queue.
+
+The next few lines determine whether a preemption / scheduling decision is required. No change in scheduling is required if the previous task does not self-suspend or complete and if no higher-priority work is pending. Note that this involves calling the `demo_job_completion()` helper function, which is simply a wrapper around `prepare_for_next_period`, as described above.
+
+The final lines carry out the actual scheduling decision. If `prev` needs to be preempted (in the `if (resched)` block), then the previous task is requeued (if required) using `demo_requeue` and a new task is taken from the ready queue. Otherwise, `next` is simply the locally scheduled task, `local_state->scheduled`, which may be `NULL`. The "local state invariant" is maintained by the `local_state->scheduled = next` assignment.
+
+## Testing
+
+With these changes in place, the kernel should compile and boot without problems. However, scheduling is still not possible because all tasks are still being rejected. Before tasks can be accepted, however, we need to add support for task state changes (i.e., self-suspensions).
+
+<div class="nav">
+[Previous: Step 4 - Per-CPU state](plugin_step_4.html) -
+[Next: Step 6 - Task state changes](plugin_step_6.html)
+</div>

--- a/create_plugin/plugin_step_6.md
+++ b/create_plugin/plugin_step_6.md
@@ -1,0 +1,149 @@
+Title:  Writing a Scheduler Plugin: Step 6
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 6: Task state changes
+==========================
+
+Changes to Task state, and in particular self-suspensions (such as waiting for I/O), are one of the "real-world" aspects that make scheduling difficult in practice.
+
+The scheduling function implemented in the previous step handles tasks that suspend because a task must be scheduled before it can self-suspend. In addition, a plugin also needs to handle "new" tasks (i.e., tasks that transition to real-time mode) and exiting tasks (i.e., tasks that leave real-time mode or quit unexpectedly). Finally, any plugin must handle resuming tasks (i.e., tasks that become available for execution again after a self-suspension ends).
+
+{{TOC}}
+
+## New and exiting tasks
+
+A task is considered "new" when it becomes a real-time task. New tasks may be either already running or suspended. If a real-time task initializes itself, it should already be running when our plugin is notified. On the other hand, real-time tasks initialized by a separate initialization task are likely to be "new" while still in a suspended state.
+
+In either case, the scheduler state pertaining to this task must be properly initialized:
+
+ - The release time of the current job and its deadline must be set.
+ - A running task must further be recorded in the `->scheduled` field of the local `struct demo_cpu_state` instance.
+ - A task that is not running but part of the runqueue must be added to the ready queue.
+
+All of this logic is contained in this `demo_task_new` function, that should be added to `sched_demo.c`:
+
+```C
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+```
+
+Als add the `demo_task_exit` function to maintain scheduler state when a task exits. Much of the boilerplate code here is identical to that in `demo_task_new`:
+
+```C
+static void demo_task_exit(struct task_struct *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        /* For simplicity, we assume here that the task is no longer queued anywhere else. This
+         * is the case when tasks exit by themselves; additional queue management is
+         * is required if tasks are forced out of real-time mode by other tasks. */
+
+        if (state->scheduled == tsk) {
+                state->scheduled = NULL;
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+```
+
+Note that for the purpose of keeping the tutorial simple, the above implementation of `demo_task_exit()` does not handle the case where one task revokes the real-time status of a different task that is still queued on the ready queue. A robust implementation could handle this by checking whether the exiting task is still part of some queue. This tutorial is just for learning and testing purposes, though, so we will simply avoid creating such a situation in our testing.
+
+## Resuming tasks
+
+Tasks that resume must be re-added to the ready or release queue, depending on when they resume. Additionally, sporadic tasks that were suspended for a "long" time are considered to experience a sporadic job release and must be given a new budget and deadline. This logic is contained in the `demo_task_resume` function, which should be added to `sched_demo.c`:
+
+```C
+/* Called when the state of tsk changes back to TASK_RUNNING.
+ * We need to requeue the task.
+ *
+ * NOTE: If a sporadic task is suspended for a long time,
+ * this might actually be an event-driven release of a new job.
+ */
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "woke up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+```
+
+There are two important things to note. First, on the line assigning `*state = cpu_state_for(...)`, note that the CPU processing the wakeup is not necessarily the CPU that the task is assigned to. This is because tasks are often resumed by interrupts, which (in general) may be handled on any CPU.
+
+Second, note that it may be the case that tsk is still scheduled, which we check using `if (state->scheduled != tsk)`. This can happen if the wakeup happens shortly after the task initiated its self-suspension, which allows the wakeup on a remote CPU to race with the suspension and to be handled before the local CPU managed to process the self-suspension. (Note that the ready queue lock serializes remote wakeups and local scheduling decisions.)
+
+## Plugin definition
+
+Finally, update the `struct sched_plugin` instance to include our plugin's new callback functions:
+
+```C
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .activate_plugin        = demo_activate_plugin,
+};
+```
+
+## Testing the changes
+
+Now, you can make sure the plugin still compiles and runs. It still won't admit tasks, though. In the next step, we'll enable preemptive scheduling.
+
+<div class="nav">
+[Previous: Step 5 - Scheduling logic](plugin_step_5.html) -
+[Next: Step 7 - Preemption](plugin_step_7.html)
+</div>

--- a/create_plugin/plugin_step_6.md
+++ b/create_plugin/plugin_step_6.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 6: Task state changes
-==========================
+--------------------------
 
 Changes to Task state, and in particular self-suspensions (such as waiting for I/O), are one of the "real-world" aspects that make scheduling difficult in practice.
 
@@ -142,6 +142,10 @@ static struct sched_plugin demo_plugin = {
 ## Testing the changes
 
 Now, you can make sure the plugin still compiles and runs. It still won't admit tasks, though. In the next step, we'll enable preemptive scheduling.
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step6.c).
 
 <div class="nav">
 [Previous: Step 5 - Scheduling logic](plugin_step_5.html) -

--- a/create_plugin/plugin_step_6.md
+++ b/create_plugin/plugin_step_6.md
@@ -12,7 +12,7 @@ The scheduling function implemented in the previous step handles tasks that susp
 
 {{TOC}}
 
-## New and exiting tasks
+### New and exiting tasks
 
 A task is considered "new" when it becomes a real-time task. New tasks may be either already running or suspended. If a real-time task initializes itself, it should already be running when our plugin is notified. On the other hand, real-time tasks initialized by a separate initialization task are likely to be "new" while still in a suspended state.
 
@@ -80,7 +80,7 @@ static void demo_task_exit(struct task_struct *tsk)
 
 Note that for the purpose of keeping the tutorial simple, the above implementation of `demo_task_exit()` does not handle the case where one task revokes the real-time status of a different task that is still queued on the ready queue. A robust implementation could handle this by checking whether the exiting task is still part of some queue. This tutorial is just for learning and testing purposes, though, so we will simply avoid creating such a situation in our testing.
 
-## Resuming tasks
+### Resuming tasks
 
 Tasks that resume must be re-added to the ready or release queue, depending on when they resume. Additionally, sporadic tasks that were suspended for a "long" time are considered to experience a sporadic job release and must be given a new budget and deadline. This logic is contained in the `demo_task_resume` function, which should be added to `sched_demo.c`:
 
@@ -123,7 +123,7 @@ There are two important things to note. First, on the line assigning `*state = c
 
 Second, note that it may be the case that tsk is still scheduled, which we check using `if (state->scheduled != tsk)`. This can happen if the wakeup happens shortly after the task initiated its self-suspension, which allows the wakeup on a remote CPU to race with the suspension and to be handled before the local CPU managed to process the self-suspension. (Note that the ready queue lock serializes remote wakeups and local scheduling decisions.)
 
-## Plugin definition
+### Plugin definition
 
 Finally, update the `struct sched_plugin` instance to include our plugin's new callback functions:
 
@@ -139,11 +139,11 @@ static struct sched_plugin demo_plugin = {
 };
 ```
 
-## Testing the changes
+### Testing the changes
 
 Now, you can make sure the plugin still compiles and runs. It still won't admit tasks, though. In the next step, we'll enable preemptive scheduling.
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step6.c).
 

--- a/create_plugin/plugin_step_7.md
+++ b/create_plugin/plugin_step_7.md
@@ -1,0 +1,150 @@
+Title:  Writing a Scheduler Plugin: Step 7
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 7: Adding preemption checks
+================================
+
+The scheduling logic so far selects the next job to be scheduled using EDF priorities whenever the scheduler is invoked. However, the scheduler still does not implement _preemptive_ EDF scheduling because it is not automatically invoked when a new job is released. In this step, we are going to rectify this by adding a preemption check callback to the real-time domain `local_queues` embedded in `struct demo_cpu_state`.
+
+{{TOC}}
+
+## Preemption check callback
+
+The preemption check callback is invoked by the `rt_domain_t` code whenever a job is transferred from the release queue to the ready queue (i.e., when a future release is processed). Since the callback is invoked from within the `rt_domain_t` code, the calling thread already holds the ready queue lock.
+
+The necessary logic is contained in the following callback function, which should be added somehwere before the `demo_activate_plugin` function to `sched_demo.c`:
+
+```C
+static int demo_check_for_preemption_on_release(rt_domain_t *local_queues)
+{
+        struct demo_cpu_state *state = container_of(local_queues, struct demo_cpu_state,
+                                                    local_queues);
+
+        /* Because this is a callback from rt_domain_t we already hold
+         * the necessary lock for the ready queue. */
+
+        if (edf_preemption_needed(local_queues, state->scheduled)) {
+                preempt_if_preemptable(state->scheduled, state->cpu);
+                return 1;
+        }
+        return 0;
+}
+```
+
+The preemption check first extracts the containing `struct demo_cpu_state` from the `rt_domain_t` pointer using Linux's standard macro `container_of()`. It then checks whether the ready queue contains a job that has higher priority (an earlier deadline) than the currently scheduled job (if any). If this is the case, then an invocation of the scheduler is triggered with the `preempt_if_preemptable()` function. This LITMUS^RT helper function is a wrapper around Linux's preemption mechanism and transparently works for both remote cores and the local core.
+
+Note that `state->scheduled` may be `NULL`; this case is transparently handled by `preempt_if_preemptable()`. (The `...if_preemptable()` suffix of the function refers to non-preemptive section support and is of no relevance to this tutorial.)
+
+## Updating the plugin initialization function
+
+The preemption check callback must be passed to the `edf_domain_init()` function during plugin initialization. Modify `demo_activate_plugin` to reflect this:
+
+```C
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+                state = cpu_state_for(cpu);
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues,
+                                demo_check_for_preemption_on_release,
+                                NULL);
+        }
+        return 0;
+}
+```
+
+## Ready queue updates
+
+Additional preemption checks are required whenever the ready queue may be changed due to resuming or new tasks. For instance, when a higher-priority task resumes, `demo_schedule()` should be invoked immediately if the currently scheduled task has lower priority (or if currently no real-time task is scheduled).
+
+To ensure the scheduler is invoked when required, we add am explicit preemption check to `demo_task_resume()`. Modify the function to contain the following code:
+
+```C
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "wake_up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+                if (edf_preemption_needed(&state->local_queues, state->scheduled)) {
+                        preempt_if_preemptable(state->scheduled, state->cpu);
+                }
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+```
+
+The only difference here is the additional check in the `if (state->scheduled != tsk)` block, where we check for preemption again.
+
+We need to make very similar changes to the `demo_task_new` function:
+
+```C
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        if (edf_preemption_needed(&state->local_queues, state->scheduled))
+                preempt_if_preemptable(state->scheduled, state->cpu);
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+```
+
+Once again, the only change is the addition of the `if (edf_preemption_needed ...` statement.
+
+## Testing
+
+Once again, make sure that the plugin compiles and runs. In the next step, we'll finally let it accept real-time tasks.
+
+<div class="nav">
+[Previous: Step 6 - Task state changes](plugin_step_6.html) -
+[Next: Step 8 - Admitting tasks](plugin_step_8.html)
+</div>

--- a/create_plugin/plugin_step_7.md
+++ b/create_plugin/plugin_step_7.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 7: Adding preemption checks
-================================
+--------------------------------
 
 The scheduling logic so far selects the next job to be scheduled using EDF priorities whenever the scheduler is invoked. However, the scheduler still does not implement _preemptive_ EDF scheduling because it is not automatically invoked when a new job is released. In this step, we are going to rectify this by adding a preemption check callback to the real-time domain `local_queues` embedded in `struct demo_cpu_state`.
 
@@ -143,6 +143,10 @@ Once again, the only change is the addition of the `if (edf_preemption_needed ..
 ## Testing
 
 Once again, make sure that the plugin compiles and runs. In the next step, we'll finally let it accept real-time tasks.
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step7.c).
 
 <div class="nav">
 [Previous: Step 6 - Task state changes](plugin_step_6.html) -

--- a/create_plugin/plugin_step_7.md
+++ b/create_plugin/plugin_step_7.md
@@ -10,7 +10,7 @@ The scheduling logic so far selects the next job to be scheduled using EDF prior
 
 {{TOC}}
 
-## Preemption check callback
+### Preemption check callback
 
 The preemption check callback is invoked by the `rt_domain_t` code whenever a job is transferred from the release queue to the ready queue (i.e., when a future release is processed). Since the callback is invoked from within the `rt_domain_t` code, the calling thread already holds the ready queue lock.
 
@@ -37,7 +37,7 @@ The preemption check first extracts the containing `struct demo_cpu_state` from 
 
 Note that `state->scheduled` may be `NULL`; this case is transparently handled by `preempt_if_preemptable()`. (The `...if_preemptable()` suffix of the function refers to non-preemptive section support and is of no relevance to this tutorial.)
 
-## Updating the plugin initialization function
+### Updating the plugin initialization function
 
 The preemption check callback must be passed to the `edf_domain_init()` function during plugin initialization. Modify `demo_activate_plugin` to reflect this:
 
@@ -60,7 +60,7 @@ static long demo_activate_plugin(void)
 }
 ```
 
-## Ready queue updates
+### Ready queue updates
 
 Additional preemption checks are required whenever the ready queue may be changed due to resuming or new tasks. For instance, when a higher-priority task resumes, `demo_schedule()` should be invoked immediately if the currently scheduled task has lower priority (or if currently no real-time task is scheduled).
 
@@ -140,11 +140,11 @@ static void demo_task_new(struct task_struct *tsk, int on_runqueue,
 
 Once again, the only change is the addition of the `if (edf_preemption_needed ...` statement.
 
-## Testing
+### Testing
 
 Once again, make sure that the plugin compiles and runs. In the next step, we'll finally let it accept real-time tasks.
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step7.c).
 

--- a/create_plugin/plugin_step_8.md
+++ b/create_plugin/plugin_step_8.md
@@ -1,0 +1,33 @@
+Title:  Writing a Scheduler Plugin: Step 8
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+Step 8: Admitting real-time tasks
+=================================
+
+In the final step before the plugin can be used to schedule real-time tasks, we are going to change to `demo_admit_task()` callback to allow tasks, provided that they are located on the right core.
+
+To this end, `change demo_admit_task()` to look as follows:
+
+```C
+static long demo_admit_task(struct task_struct *tsk)
+{
+        if (task_cpu(tsk) == get_partition(tsk)) {
+                TRACE_TASK(tsk, "accepted by demo plugin.\n");
+                return 0;
+        }
+        return -EINVAL;
+}
+```
+
+Since `DEMO` implements a partitioned scheduler, we require that real-time tasks have migrated to the appropriated core before they become real-time tasks. This constraint simplifies the implementation of the plugin greatly and is not difficult to support in userspace (`liblitmus` contains a helper function `be_migrate_to_domain()` that can take care of this requirement).
+
+Note that `task_cpu(tsk)` is Linux's notion of where the task currently is, whereas `get_partition(tsk)` is LITMUSRT's notion of where the task is logically assigned to.
+
+The plugin is now fully functional by itself. However, `liblitmus` contains code to make migrating tasks to the right processors (or clusters of processors) easier, and this support code requires additional information from the plugin. In the next step, the plugin is changed to export the required information.
+
+<div class="nav">
+[Previous: Step 7 - Preemption](plugin_step_7.html) -
+[Next: Step 9 - `/proc` interface](plugin_step_9.html)
+</div>

--- a/create_plugin/plugin_step_8.md
+++ b/create_plugin/plugin_step_8.md
@@ -27,7 +27,7 @@ Note that `task_cpu(tsk)` is Linux's notion of where the task currently is, wher
 
 The plugin is now fully functional by itself. However, `liblitmus` contains code to make migrating tasks to the right processors (or clusters of processors) easier, and this support code requires additional information from the plugin. In the next step, the plugin is changed to export the required information.
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial is available [here](./sched_demo_step8.c).
 

--- a/create_plugin/plugin_step_8.md
+++ b/create_plugin/plugin_step_8.md
@@ -4,7 +4,7 @@ CSS:    ../inc/format.css
 {{../inc/header2.markdown}}
 
 Step 8: Admitting real-time tasks
-=================================
+---------------------------------
 
 In the final step before the plugin can be used to schedule real-time tasks, we are going to change to `demo_admit_task()` callback to allow tasks, provided that they are located on the right core.
 
@@ -23,9 +23,13 @@ static long demo_admit_task(struct task_struct *tsk)
 
 Since `DEMO` implements a partitioned scheduler, we require that real-time tasks have migrated to the appropriated core before they become real-time tasks. This constraint simplifies the implementation of the plugin greatly and is not difficult to support in userspace (`liblitmus` contains a helper function `be_migrate_to_domain()` that can take care of this requirement).
 
-Note that `task_cpu(tsk)` is Linux's notion of where the task currently is, whereas `get_partition(tsk)` is LITMUSRT's notion of where the task is logically assigned to.
+Note that `task_cpu(tsk)` is Linux's notion of where the task currently is, whereas `get_partition(tsk)` is LITMUS^RT's notion of where the task is logically assigned to.
 
 The plugin is now fully functional by itself. However, `liblitmus` contains code to make migrating tasks to the right processors (or clusters of processors) easier, and this support code requires additional information from the plugin. In the next step, the plugin is changed to export the required information.
+
+## Source code
+
+The full code for this step of the tutorial is available [here](./sched_demo_step8.c).
 
 <div class="nav">
 [Previous: Step 7 - Preemption](plugin_step_7.html) -

--- a/create_plugin/plugin_step_9.md
+++ b/create_plugin/plugin_step_9.md
@@ -5,7 +5,7 @@ CSS:    ../inc/format.css
 
 <!-- Using "`proc`" (with backticks) here will break the table of contents in mmd version 5 -->
 Step 9: Exporting plugin topology in /proc
-==========================================
+------------------------------------------
 
 The userspace library `liblitmus` offers several functions that allow tasks to migrate to the appropriate CPUs under partitioned and clustered schedulers. This code needs to know which CPUs a particular plugin considers to form a "partition" or a "cluster". To enable `liblitmus` to work as intended, a plugin must hence export the required topology hints via the `/proc/` filesystem, for which LITMUS^RT provides a wrapper API.
 
@@ -141,6 +141,10 @@ sudo ./rtspin -p 1 10 100 5
 ```
 
 The `rtspin` instance in the above sample should terminate after 5 seconds and produce no output. The exact behavior of the plugin can be observed using the `sched_trace` infrastructure described in the tracing tutorial.
+
+## Source code
+
+The full code for this step of the tutorial (the full working plugin) is available [here](./sched_demo.c).
 
 <div class="nav">
 [Previous: Step 8 - Admitting tasks](plugin_step_8.html)

--- a/create_plugin/plugin_step_9.md
+++ b/create_plugin/plugin_step_9.md
@@ -1,0 +1,147 @@
+Title:  Writing a Scheduler Plugin: Step 8
+CSS:    ../inc/format.css
+
+{{../inc/header2.markdown}}
+
+<!-- Using "`proc`" (with backticks) here will break the table of contents in mmd version 5 -->
+Step 9: Exporting plugin topology in /proc
+==========================================
+
+The userspace library `liblitmus` offers several functions that allow tasks to migrate to the appropriate CPUs under partitioned and clustered schedulers. This code needs to know which CPUs a particular plugin considers to form a "partition" or a "cluster". To enable `liblitmus` to work as intended, a plugin must hence export the required topology hints via the `/proc/` filesystem, for which LITMUS^RT provides a wrapper API.
+
+{{TOC}}
+
+## Using the LITMUS^RT API to provide domain information
+
+To access the LITMUS^RT topology hints API, the plugin needs to include `litmus/litmus_proc.h`. Add the following to the list of includes in `sched_demo.c`:
+
+```C
+#include <litmus/litmus_proc.h>
+```
+
+Secondly, allocate a struct of type `struct domain_proc_info`, which will hold the required topology information. Add the following line near the beginning of `sched_demo.c`:
+
+```C
+static struct domain_proc_info demo_domain_proc_info;
+```
+
+To communicate with the `/proc` wrapper, the plugin must define another callback function, which provides a pointer to a `struct proc_domain_info` instance:
+
+```C
+static long demo_get_domain_proc_info(struct domain_proc_info **ret)
+{
+        *ret = &demo_domain_proc_info;
+        return 0;
+}
+```
+
+We'll later update the plugin's `struct sched_plugin` instance to include the `demo_get_domain_proc_info` callback, but first we will add code to initialize `demo_domain_proc_info`.
+
+## Initializing the domain info structure
+
+When the plugin is activated, the current topology must be stored in `demo_domain_proc_info`. In short, in a simple partitioned plugin such as the `DEMO` plugin, each processor forms its own "scheduling domain". The initialization code shown here iterates over all online CPUs and creates an entry for the corresponding "scheduling domain". Add this function to `sched_demo.c`, somewhere before the `demo_activate_plugin` function:
+
+```C
+static void demo_setup_domain_proc(void)
+{
+        int i, cpu;
+        int num_rt_cpus = num_online_cpus();
+
+        struct cd_mapping *cpu_map, *domain_map;
+
+        memset(&demo_domain_proc_info, 0, sizeof(demo_domain_proc_info));
+        init_domain_proc_info(&demo_domain_proc_info, num_rt_cpus, num_rt_cpus);
+        demo_domain_proc_info.num_cpus = num_rt_cpus;
+        demo_domain_proc_info.num_domains = num_rt_cpus;
+
+        i = 0;
+        for_each_online_cpu(cpu) {
+                cpu_map = &demo_domain_proc_info.cpu_to_domains[i];
+                domain_map = &demo_domain_proc_info.domain_to_cpus[i];
+
+                cpu_map->id = cpu;
+                domain_map->id = i;
+                cpumask_set_cpu(i, cpu_map->mask);
+                cpumask_set_cpu(cpu, domain_map->mask);
+                ++i;
+        }
+}
+```
+
+We'll next add a call to the `demo_setup_domain_proc` helper function in the `demo_activate_plugin` function. Modify `demo_activate_plugin` to contain the call to `demo_setup_domain_proc`:
+
+```C
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+
+                state = cpu_state_for(cpu);
+
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues, demo_check_for_preemption_on_release, NULL);
+        }
+
+        demo_setup_domain_proc();
+        return 0;
+}
+```
+
+## Adding a cleanup function
+
+LITMUS^RT supports another callback function that is invoked whenever a plugin is unloaded. We'll use this callback to tell LITMUS^RT to clean up any state used for this plugin's `/proc` interface. Add the following function to `sched_demo.c`:
+
+```C
+static long demo_deactivate_plugin(void)
+{
+        destroy_domain_proc_info(&demo_domain_proc_info);
+        return 0;
+}
+```
+
+## Registering the new callback functions
+
+Finally, we'll need to add the `demo_deactivate_plugin` and `demo_setup_domain_proc` functions to the `demo_plugin` struct:
+
+```C
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .get_domain_proc_info   = demo_get_domain_proc_info,
+        .activate_plugin        = demo_activate_plugin,
+        .deactivate_plugin      = demo_deactivate_plugin,
+};
+```
+
+## Testing
+
+With these changes in place, our P-EDF scheduler should be complete and ready for use by `liblitmus`. To test the changes:
+
+ 1. Re-compile the LITMUS^RT kernel and reboot.
+ 2. Activate the `DEMO` plugin using `setsched`.
+ 3. Launch some real-time tasks (as a test, you can use `rtspin` or `rt_launch` from `liblitmus`).
+
+```bash
+cd liblitmus
+
+# Activate the demo plugin
+sudo ./setsched DEMO
+
+# Run a real-time task. This rtspin instance should run on CPU 1, have a WCET of 10 ms,
+# a period of 100ms, and run for 5 seconds.
+sudo ./rtspin -p 1 10 100 5
+```
+
+The `rtspin` instance in the above sample should terminate after 5 seconds and produce no output. The exact behavior of the plugin can be observed using the `sched_trace` infrastructure described in the tracing tutorial.
+
+<div class="nav">
+[Previous: Step 8 - Admitting tasks](plugin_step_8.html)
+</div>

--- a/create_plugin/plugin_step_9.md
+++ b/create_plugin/plugin_step_9.md
@@ -11,7 +11,7 @@ The userspace library `liblitmus` offers several functions that allow tasks to m
 
 {{TOC}}
 
-## Using the LITMUS^RT API to provide domain information
+### Using the LITMUS^RT API to provide domain information
 
 To access the LITMUS^RT topology hints API, the plugin needs to include `litmus/litmus_proc.h`. Add the following to the list of includes in `sched_demo.c`:
 
@@ -37,7 +37,7 @@ static long demo_get_domain_proc_info(struct domain_proc_info **ret)
 
 We'll later update the plugin's `struct sched_plugin` instance to include the `demo_get_domain_proc_info` callback, but first we will add code to initialize `demo_domain_proc_info`.
 
-## Initializing the domain info structure
+### Initializing the domain info structure
 
 When the plugin is activated, the current topology must be stored in `demo_domain_proc_info`. In short, in a simple partitioned plugin such as the `DEMO` plugin, each processor forms its own "scheduling domain". The initialization code shown here iterates over all online CPUs and creates an entry for the corresponding "scheduling domain". Add this function to `sched_demo.c`, somewhere before the `demo_activate_plugin` function:
 
@@ -91,7 +91,7 @@ static long demo_activate_plugin(void)
 }
 ```
 
-## Adding a cleanup function
+### Adding a cleanup function
 
 LITMUS^RT supports another callback function that is invoked whenever a plugin is unloaded. We'll use this callback to tell LITMUS^RT to clean up any state used for this plugin's `/proc` interface. Add the following function to `sched_demo.c`:
 
@@ -103,7 +103,7 @@ static long demo_deactivate_plugin(void)
 }
 ```
 
-## Registering the new callback functions
+### Registering the new callback functions
 
 Finally, we'll need to add the `demo_deactivate_plugin` and `demo_setup_domain_proc` functions to the `demo_plugin` struct:
 
@@ -121,7 +121,7 @@ static struct sched_plugin demo_plugin = {
 };
 ```
 
-## Testing
+### Testing
 
 With these changes in place, our P-EDF scheduler should be complete and ready for use by `liblitmus`. To test the changes:
 
@@ -142,7 +142,7 @@ sudo ./rtspin -p 1 10 100 5
 
 The `rtspin` instance in the above sample should terminate after 5 seconds and produce no output. The exact behavior of the plugin can be observed using the `sched_trace` infrastructure described in the tracing tutorial.
 
-## Source code
+### Source code
 
 The full code for this step of the tutorial (the full working plugin) is available [here](./sched_demo.c).
 

--- a/create_plugin/sched_demo.c
+++ b/create_plugin/sched_demo.c
@@ -1,11 +1,12 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
+#include <litmus/litmus.h>
 #include <litmus/budget.h>
 #include <litmus/edf_common.h>
 #include <litmus/jobs.h>
-#include <litmus/litmus.h>
 #include <litmus/litmus_proc.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>
@@ -289,6 +290,7 @@ static struct sched_plugin demo_plugin = {
         .admit_task             = demo_admit_task,
         .task_new               = demo_task_new,
         .task_exit              = demo_task_exit,
+        .get_domain_proc_info   = demo_get_domain_proc_info,
         .activate_plugin        = demo_activate_plugin,
         .deactivate_plugin      = demo_deactivate_plugin,
 };

--- a/create_plugin/sched_demo.c
+++ b/create_plugin/sched_demo.c
@@ -1,0 +1,302 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/budget.h>
+#include <litmus/edf_common.h>
+#include <litmus/jobs.h>
+#include <litmus/litmus.h>
+#include <litmus/litmus_proc.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+static struct domain_proc_info demo_domain_proc_info;
+
+static long demo_get_domain_proc_info(struct domain_proc_info **ret)
+{
+        *ret = &demo_domain_proc_info;
+        return 0;
+}
+
+static void demo_setup_domain_proc(void)
+{
+        int i, cpu;
+        int num_rt_cpus = num_online_cpus();
+
+        struct cd_mapping *cpu_map, *domain_map;
+
+        memset(&demo_domain_proc_info, 0, sizeof(demo_domain_proc_info));
+        init_domain_proc_info(&demo_domain_proc_info, num_rt_cpus, num_rt_cpus);
+        demo_domain_proc_info.num_cpus = num_rt_cpus;
+        demo_domain_proc_info.num_domains = num_rt_cpus;
+
+        i = 0;
+        for_each_online_cpu(cpu) {
+                cpu_map = &demo_domain_proc_info.cpu_to_domains[i];
+                domain_map = &demo_domain_proc_info.domain_to_cpus[i];
+
+                cpu_map->id = cpu;
+                domain_map->id = i;
+                cpumask_set_cpu(i, cpu_map->mask);
+                cpumask_set_cpu(cpu, domain_map->mask);
+                ++i;
+        }
+}
+
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+
+static int demo_check_for_preemption_on_release(rt_domain_t *local_queues)
+{
+        struct demo_cpu_state *state = container_of(local_queues, struct demo_cpu_state,
+                                                    local_queues);
+
+        /* Because this is a callback from rt_domain_t we already hold
+         * the necessary lock for the ready queue. */
+
+        if (edf_preemption_needed(local_queues, state->scheduled)) {
+                preempt_if_preemptable(state->scheduled, state->cpu);
+                return 1;
+        }
+        return 0;
+}
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+                state = cpu_state_for(cpu);
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues,
+                                demo_check_for_preemption_on_release,
+                                NULL);
+        }
+
+        demo_setup_domain_proc();
+        return 0;
+}
+
+static long demo_deactivate_plugin(void)
+{
+        destroy_domain_proc_info(&demo_domain_proc_info);
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        if (task_cpu(tsk) == get_partition(tsk)) {
+                TRACE_TASK(tsk, "accepted by demo plugin.\n");
+                return 0;
+        }
+        return -EINVAL;
+}
+
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        if (edf_preemption_needed(&state->local_queues, state->scheduled))
+                preempt_if_preemptable(state->scheduled, state->cpu);
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static void demo_task_exit(struct task_struct *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        /* For simplicity, we assume here that the task is no longer queued anywhere else. This
+         * is the case when tasks exit by themselves; additional queue management is
+         * is required if tasks are forced out of real-time mode by other tasks. */
+
+        if (state->scheduled == tsk) {
+                state->scheduled = NULL;
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+/* Called when the state of tsk changes back to TASK_RUNNING.
+ * We need to requeue the task.
+ *
+ * NOTE: If a sporadic task is suspended for a long time,
+ * this might actually be an event-driven release of a new job.
+ */
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "wake_up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+                if (edf_preemption_needed(&state->local_queues, state->scheduled)) {
+                        preempt_if_preemptable(state->scheduled, state->cpu);
+                }
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .activate_plugin        = demo_activate_plugin,
+        .deactivate_plugin      = demo_deactivate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step2.c
+++ b/create_plugin/sched_demo_step2.c
@@ -1,0 +1,35 @@
+#include <linux/module.h>
+#include <litmus/preempt.h>
+#include <litmus/sched_plugin.h>
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        /* We don't schedule anything for now. NULL means "schedule background work". */
+        return NULL;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step3.c
+++ b/create_plugin/sched_demo_step3.c
@@ -1,4 +1,5 @@
 #include <linux/module.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/sched_plugin.h>
 

--- a/create_plugin/sched_demo_step3.c
+++ b/create_plugin/sched_demo_step3.c
@@ -1,0 +1,36 @@
+#include <linux/module.h>
+#include <litmus/preempt.h>
+#include <litmus/sched_plugin.h>
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        /* We don't schedule anything for now. NULL means "schedule background work". */
+        return NULL;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step4.c
+++ b/create_plugin/sched_demo_step4.c
@@ -1,8 +1,9 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
-#include <litmus/edf_common.h>
 #include <litmus/litmus.h>
+#include <litmus/edf_common.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>

--- a/create_plugin/sched_demo_step4.c
+++ b/create_plugin/sched_demo_step4.c
@@ -1,0 +1,72 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/edf_common.h>
+#include <litmus/litmus.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        // Use our macros to access the per-CPU state for all CPUs
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+
+                state = cpu_state_for(cpu);
+
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues, NULL, NULL);
+        }
+
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        /* We don't schedule anything for now. NULL means "schedule background work". */
+        return NULL;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+        .activate_plugin        = demo_activate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step5.c
+++ b/create_plugin/sched_demo_step5.c
@@ -1,0 +1,154 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/budget.h>
+#include <litmus/edf_common.h>
+#include <litmus/jobs.h>
+#include <litmus/litmus.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        // Use our macros to access the per-CPU state for all CPUs
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+
+                state = cpu_state_for(cpu);
+
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues, NULL, NULL);
+        }
+
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .admit_task             = demo_admit_task,
+        .activate_plugin        = demo_activate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step5.c
+++ b/create_plugin/sched_demo_step5.c
@@ -1,10 +1,11 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
+#include <litmus/litmus.h>
 #include <litmus/budget.h>
 #include <litmus/edf_common.h>
 #include <litmus/jobs.h>
-#include <litmus/litmus.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>

--- a/create_plugin/sched_demo_step6.c
+++ b/create_plugin/sched_demo_step6.c
@@ -1,0 +1,238 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/budget.h>
+#include <litmus/edf_common.h>
+#include <litmus/jobs.h>
+#include <litmus/litmus.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        // Use our macros to access the per-CPU state for all CPUs
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+
+                state = cpu_state_for(cpu);
+
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues, NULL, NULL);
+        }
+
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static void demo_task_exit(struct task_struct *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        /* For simplicity, we assume here that the task is no longer queued anywhere else. This
+         * is the case when tasks exit by themselves; additional queue management is
+         * is required if tasks are forced out of real-time mode by other tasks. */
+
+        if (state->scheduled == tsk) {
+                state->scheduled = NULL;
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+/* Called when the state of tsk changes back to TASK_RUNNING.
+ * We need to requeue the task.
+ *
+ * NOTE: If a sporadic task is suspended for a long time,
+ * this might actually be an event-driven release of a new job.
+ */
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "woke up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .activate_plugin        = demo_activate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step6.c
+++ b/create_plugin/sched_demo_step6.c
@@ -1,10 +1,11 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
+#include <litmus/litmus.h>
 #include <litmus/budget.h>
 #include <litmus/edf_common.h>
 #include <litmus/jobs.h>
-#include <litmus/litmus.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>

--- a/create_plugin/sched_demo_step7.c
+++ b/create_plugin/sched_demo_step7.c
@@ -1,0 +1,257 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/budget.h>
+#include <litmus/edf_common.h>
+#include <litmus/jobs.h>
+#include <litmus/litmus.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+
+static int demo_check_for_preemption_on_release(rt_domain_t *local_queues)
+{
+        struct demo_cpu_state *state = container_of(local_queues, struct demo_cpu_state,
+                                                    local_queues);
+
+        /* Because this is a callback from rt_domain_t we already hold
+         * the necessary lock for the ready queue. */
+
+        if (edf_preemption_needed(local_queues, state->scheduled)) {
+                preempt_if_preemptable(state->scheduled, state->cpu);
+                return 1;
+        }
+        return 0;
+}
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+                state = cpu_state_for(cpu);
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues,
+                                demo_check_for_preemption_on_release,
+                                NULL);
+        }
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        TRACE_TASK(tsk, "The task was rejected by the demo plugin.\n");
+        /* Reject every task. */
+        return -EINVAL;
+}
+
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        if (edf_preemption_needed(&state->local_queues, state->scheduled))
+                preempt_if_preemptable(state->scheduled, state->cpu);
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static void demo_task_exit(struct task_struct *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        /* For simplicity, we assume here that the task is no longer queued anywhere else. This
+         * is the case when tasks exit by themselves; additional queue management is
+         * is required if tasks are forced out of real-time mode by other tasks. */
+
+        if (state->scheduled == tsk) {
+                state->scheduled = NULL;
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+/* Called when the state of tsk changes back to TASK_RUNNING.
+ * We need to requeue the task.
+ *
+ * NOTE: If a sporadic task is suspended for a long time,
+ * this might actually be an event-driven release of a new job.
+ */
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "wake_up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+                if (edf_preemption_needed(&state->local_queues, state->scheduled)) {
+                        preempt_if_preemptable(state->scheduled, state->cpu);
+                }
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .activate_plugin        = demo_activate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step7.c
+++ b/create_plugin/sched_demo_step7.c
@@ -1,10 +1,11 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
+#include <litmus/litmus.h>
 #include <litmus/budget.h>
 #include <litmus/edf_common.h>
 #include <litmus/jobs.h>
-#include <litmus/litmus.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>

--- a/create_plugin/sched_demo_step8.c
+++ b/create_plugin/sched_demo_step8.c
@@ -1,0 +1,259 @@
+#include <linux/module.h>
+#include <linux/percpu.h>
+#include <linux/sched.h>
+#include <litmus/budget.h>
+#include <litmus/edf_common.h>
+#include <litmus/jobs.h>
+#include <litmus/litmus.h>
+#include <litmus/preempt.h>
+#include <litmus/rt_domain.h>
+#include <litmus/sched_plugin.h>
+
+struct demo_cpu_state {
+        rt_domain_t local_queues;
+        int cpu;
+        struct task_struct* scheduled;
+};
+
+static DEFINE_PER_CPU(struct demo_cpu_state, demo_cpu_state);
+
+#define cpu_state_for(cpu_id)   (&per_cpu(demo_cpu_state, cpu_id))
+#define local_cpu_state()       (this_cpu_ptr(&demo_cpu_state))
+
+/* This helper is called when task `prev` exhausted its budget or when
+ * it signaled a job completion. */
+static void demo_job_completion(struct task_struct *prev, int budget_exhausted)
+{
+        /* Call common helper code to compute the next release time, deadline,
+         * etc. */
+        prepare_for_next_period(prev);
+}
+
+/* Add the task `tsk` to the appropriate queue. Assumes the caller holds the ready lock.
+ */
+static void demo_requeue(struct task_struct *tsk, struct demo_cpu_state *cpu_state)
+{
+        if (is_released(tsk, litmus_clock())) {
+                /* Uses __add_ready() instead of add_ready() because we already
+                 * hold the ready lock. */
+                __add_ready(&cpu_state->local_queues, tsk);
+        } else {
+                /* Uses add_release() because we DON'T have the release lock. */
+                add_release(&cpu_state->local_queues, tsk);
+        }
+}
+
+static int demo_check_for_preemption_on_release(rt_domain_t *local_queues)
+{
+        struct demo_cpu_state *state = container_of(local_queues, struct demo_cpu_state,
+                                                    local_queues);
+
+        /* Because this is a callback from rt_domain_t we already hold
+         * the necessary lock for the ready queue. */
+
+        if (edf_preemption_needed(local_queues, state->scheduled)) {
+                preempt_if_preemptable(state->scheduled, state->cpu);
+                return 1;
+        }
+        return 0;
+}
+
+static long demo_activate_plugin(void)
+{
+        int cpu;
+        struct demo_cpu_state *state;
+
+        for_each_online_cpu(cpu) {
+                TRACE("Initializing CPU%d...\n", cpu);
+                state = cpu_state_for(cpu);
+                state->cpu = cpu;
+                state->scheduled = NULL;
+                edf_domain_init(&state->local_queues,
+                                demo_check_for_preemption_on_release,
+                                NULL);
+        }
+        return 0;
+}
+
+static struct task_struct* demo_schedule(struct task_struct * prev)
+{
+        struct demo_cpu_state *local_state = local_cpu_state();
+
+        /* next == NULL means "schedule background work". */
+        struct task_struct *next = NULL;
+
+        /* prev's task state */
+        int exists, out_of_time, job_completed, self_suspends, preempt, resched;
+
+        raw_spin_lock(&local_state->local_queues.ready_lock);
+
+        BUG_ON(local_state->scheduled && local_state->scheduled != prev);
+        BUG_ON(local_state->scheduled && !is_realtime(prev));
+
+        exists = local_state->scheduled != NULL;
+        self_suspends = exists && !is_current_running();
+        out_of_time = exists && budget_enforced(prev) && budget_exhausted(prev);
+        job_completed = exists && is_completed(prev);
+
+        /* preempt is true if task `prev` has lower priority than something on
+         * the ready queue. */
+        preempt = edf_preemption_needed(&local_state->local_queues, prev);
+
+        /* check all conditions that make us reschedule */
+        resched = preempt;
+
+        /* if `prev` suspends, it CANNOT be scheduled anymore => reschedule */
+        if (self_suspends) {
+                resched = 1;
+        }
+
+        /* also check for (in-)voluntary job completions */
+        if (out_of_time || job_completed) {
+                demo_job_completion(prev, out_of_time);
+                resched = 1;
+        }
+
+        if (resched) {
+                /* First check if the previous task goes back onto the ready
+                 * queue, which it does if it did not self_suspend.
+                 */
+                if (exists && !self_suspends) {
+                        demo_requeue(prev, local_state);
+                }
+                next = __take_ready(&local_state->local_queues);
+        } else {
+                /* No preemption is required. */
+                next = local_state->scheduled;
+        }
+
+        local_state->scheduled = next;
+        if (exists && prev != next) {
+                TRACE_TASK(prev, "descheduled.\n");
+        }
+        if (next) {
+                TRACE_TASK(next, "scheduled.\n");
+        }
+
+        /* This mandatory. It triggers a transition in the LITMUS^RT remote
+         * preemption state machine. Call this AFTER the plugin has made a local
+         * scheduling decision.
+         */
+        sched_state_task_picked();
+
+        raw_spin_unlock(&local_state->local_queues.ready_lock);
+        return next;
+}
+
+static long demo_admit_task(struct task_struct *tsk)
+{
+        if (task_cpu(tsk) == get_partition(tsk)) {
+                TRACE_TASK(tsk, "accepted by demo plugin.\n");
+                return 0;
+        }
+        return -EINVAL;
+}
+
+static void demo_task_new(struct task_struct *tsk, int on_runqueue,
+                          int is_running)
+{
+        /* We'll use this to store IRQ flags. */
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+
+        TRACE_TASK(tsk, "is a new RT task %llu (on runqueue:%d, running:%d)\n",
+                   litmus_clock(), on_runqueue, is_running);
+
+        /* Acquire the lock protecting the state and disable interrupts. */
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        /* Release the first job now. */
+        release_at(tsk, now);
+
+        if (is_running) {
+                /* If tsk is running, then no other task can be running
+                 * on the local CPU. */
+                BUG_ON(state->scheduled != NULL);
+                state->scheduled = tsk;
+        } else if (on_runqueue) {
+                demo_requeue(tsk, state);
+        }
+
+        if (edf_preemption_needed(&state->local_queues, state->scheduled))
+                preempt_if_preemptable(state->scheduled, state->cpu);
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static void demo_task_exit(struct task_struct *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        /* For simplicity, we assume here that the task is no longer queued anywhere else. This
+         * is the case when tasks exit by themselves; additional queue management is
+         * is required if tasks are forced out of real-time mode by other tasks. */
+
+        if (state->scheduled == tsk) {
+                state->scheduled = NULL;
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+/* Called when the state of tsk changes back to TASK_RUNNING.
+ * We need to requeue the task.
+ *
+ * NOTE: If a sporadic task is suspended for a long time,
+ * this might actually be an event-driven release of a new job.
+ */
+static void demo_task_resume(struct task_struct  *tsk)
+{
+        unsigned long flags;
+        struct demo_cpu_state *state = cpu_state_for(get_partition(tsk));
+        lt_t now;
+        TRACE_TASK(tsk, "wake_up at %llu\n", litmus_clock());
+        raw_spin_lock_irqsave(&state->local_queues.ready_lock, flags);
+
+        now = litmus_clock();
+
+        if (is_sporadic(tsk) && is_tardy(tsk, now)) {
+                /* This sporadic task was gone for a "long" time and woke up past
+                 * its deadline. Give it a new budget by triggering a job
+                 * release. */
+                release_at(tsk, now);
+        }
+
+        /* This check is required to avoid races with tasks that resume before
+         * the scheduler "noticed" that it resumed. That is, the wake up may
+         * race with the call to schedule(). */
+        if (state->scheduled != tsk) {
+                demo_requeue(tsk, state);
+                if (edf_preemption_needed(&state->local_queues, state->scheduled)) {
+                        preempt_if_preemptable(state->scheduled, state->cpu);
+                }
+        }
+
+        raw_spin_unlock_irqrestore(&state->local_queues.ready_lock, flags);
+}
+
+static struct sched_plugin demo_plugin = {
+        .plugin_name            = "DEMO",
+        .schedule               = demo_schedule,
+        .task_wake_up           = demo_task_resume,
+        .admit_task             = demo_admit_task,
+        .task_new               = demo_task_new,
+        .task_exit              = demo_task_exit,
+        .activate_plugin        = demo_activate_plugin,
+};
+
+static int __init init_demo(void)
+{
+        return register_sched_plugin(&demo_plugin);
+}
+
+module_init(init_demo);
+

--- a/create_plugin/sched_demo_step8.c
+++ b/create_plugin/sched_demo_step8.c
@@ -1,10 +1,11 @@
 #include <linux/module.h>
 #include <linux/percpu.h>
 #include <linux/sched.h>
+#include <litmus/litmus.h>
 #include <litmus/budget.h>
 #include <litmus/edf_common.h>
 #include <litmus/jobs.h>
-#include <litmus/litmus.h>
+#include <litmus/debug_trace.h>
 #include <litmus/preempt.h>
 #include <litmus/rt_domain.h>
 #include <litmus/sched_plugin.h>

--- a/documentation.md
+++ b/documentation.md
@@ -8,11 +8,11 @@ LITMUS^RT Documentation
 
 This page contains links to LITMUS^RT documentation, inluding basic installation and usage instructions, and in-depth tutorials such as creating a new scheduler plugin.
 
+- The [Installation Instructions](installation.html) cover how to compile and install the LITMUS^RT kernel for a standard Linux system.
+
  - The [LITMUS^RT Tutorial](tutorial/index.html) page contains basic instructions for getting started with using LITMUS^RT, including working with different scheduling plugins and configuring real-time tasks.
 
  - The [LITMUS^RT Manual](tutorial/manual.html) page includes more details about how LITMUS^RT and its schedulers work. This page provides more detail about the topics covered in the [basic tutorial](tutorial/index.html).
-
- - The [Installation Instructions](installation.html) cover how to compile and install the LITMUS^RT kernel for a standard Linux system.
 
  - [Writing a LITMUS^RT Scheduler Plugin](create_plugin/create_plugin.html) contains step-by-step instructions for implementing a P-EDF scheduler as a LITMUS^RT plugin. We recommend using these instructions as a starting point when implementing a new scheduler plugin.
 

--- a/documentation.md
+++ b/documentation.md
@@ -1,0 +1,21 @@
+Title:  LITMUS-RT: Documentation
+CSS:    inc/format.css
+
+{{inc/header.markdown}}
+
+LITMUS^RT Documentation
+=======================
+
+This page contains links to LITMUS^RT documentation, inluding basic installation and usage instructions, and in-depth tutorials such as creating a new scheduler plugin.
+
+ - The [LITMUS^RT Tutorial](tutorial/index.html) page contains basic instructions for getting started with using LITMUS^RT, including working with different scheduling plugins and configuring real-time tasks.
+
+ - The [LITMUS^RT Manual](tutorial/manual.html) page includes more details about how LITMUS^RT and its schedulers work. This page provides more detail about the topics covered in the [basic tutorial](tutorial/index.html).
+
+ - The [Installation Instructions](installation.html) cover how to compile and install the LITMUS^RT kernel for a standard Linux system.
+
+ - [Writing a LITMUS^RT Scheduler Plugin](create_plugin/create_plugin.html) contains step-by-step instructions for implementing a P-EDF scheduler as a LITMUS^RT plugin. We recommend using these instructions as a starting point when implementing a new scheduler plugin.
+
+ - The [LITMUS^RT Wiki](http://wiki.litmus-rt.org/) is largely unmaintained and outdated, but contains a few additional tutorials that may be useful when using LITMUS^RT.
+
+{{inc/footer.markdown}}

--- a/inc/format.css
+++ b/inc/format.css
@@ -235,6 +235,7 @@ hr {
 
 code {
 	font-family:  Menlo, Monaco, Courier, "Courier New", monospace;
+	overflow: scroll;
 }
 
 pre {
@@ -245,6 +246,7 @@ pre {
   color: #cccccc;
   border: 2px solid #cccccc;
   font-size: 11pt;
+  overflow-x: auto;
 }
 
 .shell {

--- a/inc/format.css
+++ b/inc/format.css
@@ -235,7 +235,6 @@ hr {
 
 code {
 	font-family:  Menlo, Monaco, Courier, "Courier New", monospace;
-	overflow: scroll;
 }
 
 pre {

--- a/inc/header.markdown
+++ b/inc/header.markdown
@@ -5,12 +5,9 @@
 
 <div class="nav">
 
-[about](index.html) - 
-[tutorial](tutorial/index.html) - 
-[manual](tutorial/manual.html) -
-[wiki](http://wiki.litmus-rt.org/) -
+[about](index.html) -
+[documentation](documentation.html) -
 [download](download.html) -
-[installation](installation.html) -
 [publications](http://wiki.litmus-rt.org/litmus/Publications) -
 [credits](credits.html)
 

--- a/inc/header.markdown
+++ b/inc/header.markdown
@@ -8,6 +8,7 @@
 [about](index.html) -
 [documentation](documentation.html) -
 [download](download.html) -
+[contact](contact.html) -
 [publications](http://wiki.litmus-rt.org/litmus/Publications) -
 [credits](credits.html)
 

--- a/inc/header2.markdown
+++ b/inc/header2.markdown
@@ -5,12 +5,9 @@
 
 <div class="nav">
 
-[about](../index.html) - 
-[tutorial](../tutorial/index.html) -
-[manual](../tutorial/manual.html) -
-[wiki](http://wiki.litmus-rt.org/) -
+[about](../index.html) -
+[documentation](../documentation.html) -
 [download](../download.html) -
-[installation](../installation.html) -
 [publications](http://wiki.litmus-rt.org/litmus/Publications) -
 [credits](../credits.html)
 

--- a/inc/header2.markdown
+++ b/inc/header2.markdown
@@ -8,6 +8,7 @@
 [about](../index.html) -
 [documentation](../documentation.html) -
 [download](../download.html) -
+[contact](../contact.html) -
 [publications](http://wiki.litmus-rt.org/litmus/Publications) -
 [credits](../credits.html)
 

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ scheduling policies:
 - Partitioned [Reservation-Based Scheduling](https://github.com/LITMUS-RT/liblitmus/blob/master/doc/howto-use-resctl.md) (P-RES), and
 - PD^2, with either staggered or aligned quanta (PFAIR).
 
-Please refer to the [download](download.html) and [installation](installation.html) pages for details.
+Please refer to the [download](download.html) and [documentation](documentation.html) pages for more details about installing and working with LITMUS^RT.
 
 ## Getting Help
 

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ Please refer to the [download](download.html) and [documentation](documentation.
 
 ## Getting Help
 
-To get in contact with the LITMUS^RT community, please use the <a href="https://wiki.litmus-rt.org/litmus/Mailinglist">mailing list</a>.
+To get in contact with the LITMUS^RT community, please use the [mailing list](contact.html).
 
 ## Credit
 

--- a/installation.md
+++ b/installation.md
@@ -7,7 +7,7 @@ CSS:    inc/format.css
 Installing LITMUS^RT
 ====================
 
-Working with LITMUS^RT generally requires compiling the entire LITMUS^RT kernel from source, and then installing liblitmus and Feather-Trace. The following instructions include cover all of the necessary compilation and installation steps.
+Working with LITMUS^RT generally requires compiling the entire LITMUS^RT kernel from source, and then installing liblitmus and Feather-Trace. The following instructions include all of the necessary compilation and installation steps.
 
 {{TOC}}
 

--- a/installation.md
+++ b/installation.md
@@ -7,7 +7,7 @@ CSS:    inc/format.css
 Installing LITMUS^RT
 ====================
 
-Working with LITMUS^RT generally requires compiling the entire LITMUS^RT kernel from source, and then installing liblitmus and Feather-Trace. The following instructions include all of the necessary compilation and installation steps.
+Working with LITMUS^RT generally requires compiling the entire LITMUS^RT kernel from source, and then installing liblitmus and Feather-Trace. The following instructions include cover all of the necessary compilation and installation steps.
 
 {{TOC}}
 
@@ -188,5 +188,5 @@ make
 
 ## Next Steps
 
-At this point, reboot the system into LITMUS^RT and try running a few examples. Check out the [tutorial](tutorial/index.html) for some initial steps. 
+At this point, reboot the system into LITMUS^RT and try running a few examples. Check out the [tutorial](tutorial/index.html) for some initial steps, or the [plugin creation tutorial](create_plugin/create_plugin.html) to start writing a LITMUS^RT scheduler plugin.
 

--- a/tutorial/index.md
+++ b/tutorial/index.md
@@ -30,7 +30,7 @@ This tutorial is aimed at learning how to *use* LITMUS^RT. The following topics 
 5. how to use of LITMUS^RT's built-in tracing capabilities to record and evaluate scheduling traces (e.g., to observe actual execution costs, deadline miss ratios, tardiness, preemption and migration counts, etc.), and
 6. how to measure system overheads (e.g., scheduling and context switch overheads, release latency, etc.).
 
-Kernel development is beyond the scope of this tutorial.
+Kernel development is beyond the scope of this tutorial. If you want to develop a new plugin for LITMUS^RT, see the [plugin creation tutorial](../create_plugin/create_plugin.html) instead.
 
 ## Prerequisites
 

--- a/tutorial/manual.md
+++ b/tutorial/manual.md
@@ -17,7 +17,7 @@ CSS:    ../inc/format.css
 4. comes with *Feather-Trace*, a **low-overhead tracing** framework.
 
 
-This guide provides an introduction to the user-facing parts of LITMUS^RT, namely (3) and (4), and assumes that the kernel (with the LITMUS^RT modifications in place) has already been compiled and is working. How to modify  the kernel itself, and in particular how to develop new policy plugins, is beyond the scope of this guide.
+This guide provides an introduction to the user-facing parts of LITMUS^RT, namely (3) and (4), and assumes that the kernel (with the LITMUS^RT modifications in place) has already been compiled and is working. How to modify  the kernel itself, and in particular how to develop new policy plugins, is beyond the scope of this guide. We instead refer those insterested in developing new plugins to the [plugin creation tutorial](../create_plugin/create_plugin.html).
 
 This guide describes LITMUS^RT as of version 2017.1 (released in May 2017).
 
@@ -77,7 +77,7 @@ can then be later activated (one at a time) by the root user.
 
 
 At runtime, scheduler plugins are managed via a simple `/proc` interface that is exposed under `/proc/litmus`. While all files under `/proc/litmus` can be manually read or written for management purposes,  it is often easier and more
-convenient to use the higher-level tools offered by `liblitmus`.  In the following, we discuss a list of basic user-space commands related to plugin management, followed by an example.
+convenient to use the higher-level tools offered by `liblitmus`. In the following, we discuss a list of basic user-space commands related to plugin management, followed by an example.
 
 All the commands mentioned in the following must be executed as root.
 


### PR DESCRIPTION
This PR includes:

 - A rewritten 9-step plugin creation tutorial compatible with the current LITMUS^RT version.

 - Added a "contact" page to the top-level navigation.

 - Removed "wiki", "tutorial", "manual", and "installation" from the top-level navigation, and merged them into a new top-level "documentation" page.

 - On the main page: Replaced a link to the wiki's mailing list page with a link to the new contact page.